### PR TITLE
feat: create portfolio site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
-# meghna-website
-Portfolio website for Meghna
+# Meghna Sahni Portfolio
+
+A simple static portfolio for **Meghna Sahni** inspired by [blahatrohit.webflow.io](https://blahatrohit.webflow.io/). It includes a hero banner, about section, project gallery, and a contact form.
+
+## Local Development
+
+Open `index.html` in a web browser to view the site locally.
+
+## Hosting on GitHub Pages
+
+1. Push this repository to a GitHub repository named `username.github.io`, or enable Pages in the repository settings.
+2. The site will be available at `https://username.github.io` after GitHub Pages builds the site.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Meghna Sahni | Portfolio</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="navbar">
+    <div class="container">
+      <h1 class="logo">Meghna Sahni</h1>
+      <nav>
+        <ul class="nav-links">
+          <li><a href="#home">Home</a></li>
+          <li><a href="#about">About</a></li>
+          <li><a href="#projects">Projects</a></li>
+          <li><a href="#contact">Contact</a></li>
+        </ul>
+        <button class="nav-toggle" aria-label="toggle navigation">&#9776;</button>
+      </nav>
+    </div>
+  </header>
+
+  <section id="home" class="hero">
+    <div class="container">
+      <h2>Hello, I'm <span>Meghna</span></h2>
+      <p class="tagline">Designer &amp; Developer crafting delightful digital experiences.</p>
+      <a href="#projects" class="btn">View My Work</a>
+    </div>
+  </section>
+
+  <section id="about">
+    <div class="container">
+      <h2>About Me</h2>
+      <p>I'm Meghna Sahni, a creative professional passionate about building clean and engaging user experiences. I enjoy turning complex problems into simple, beautiful designs.</p>
+    </div>
+  </section>
+
+  <section id="projects">
+    <div class="container">
+      <h2>Projects</h2>
+      <div class="projects-grid">
+        <div class="project-card">
+          <img src="https://via.placeholder.com/400x300" alt="Project one screenshot" />
+          <h3>Project One</h3>
+          <p>Brief description of the project highlighting tools and impact.</p>
+        </div>
+        <div class="project-card">
+          <img src="https://via.placeholder.com/400x300" alt="Project two screenshot" />
+          <h3>Project Two</h3>
+          <p>Another project summary showcasing problem solving and design.</p>
+        </div>
+        <div class="project-card">
+          <img src="https://via.placeholder.com/400x300" alt="Project three screenshot" />
+          <h3>Project Three</h3>
+          <p>Describe the third project or case study in a sentence or two.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="contact">
+    <div class="container">
+      <h2>Contact</h2>
+      <form class="contact-form">
+        <label for="name">Name</label>
+        <input type="text" id="name" name="name" required />
+        <label for="email">Email</label>
+        <input type="email" id="email" name="email" required />
+        <label for="message">Message</label>
+        <textarea id="message" name="message" rows="5" required></textarea>
+        <button type="submit">Send</button>
+      </form>
+    </div>
+  </section>
+
+  <footer>
+    <p>&copy; <span id="year"></span> Meghna Sahni</p>
+  </footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,34 @@
+// Set the current year in the footer
+document.getElementById('year').textContent = new Date().getFullYear();
+
+// Smooth scrolling for internal links
+document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+  anchor.addEventListener('click', e => {
+    e.preventDefault();
+    document.querySelector(anchor.getAttribute('href')).scrollIntoView({
+      behavior: 'smooth'
+    });
+  });
+});
+
+// Mobile navigation toggle
+const navToggle = document.querySelector('.nav-toggle');
+const navLinks = document.querySelector('.nav-links');
+
+navToggle.addEventListener('click', () => {
+  navLinks.classList.toggle('open');
+});
+
+// Simple contact form handler
+const form = document.querySelector('.contact-form');
+if (form) {
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    const name = document.getElementById('name').value;
+    const email = document.getElementById('email').value;
+    const message = document.getElementById('message').value;
+    const subject = `Portfolio Inquiry from ${encodeURIComponent(name)}`;
+    const body = `${encodeURIComponent(message)}%0A%0AFrom:%20${encodeURIComponent(email)}`;
+    window.location.href = `mailto:meghna@example.com?subject=${subject}&body=${body}`;
+  });
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,147 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  line-height: 1.6;
+  color: #333;
+}
+
+header.navbar {
+  background: #fff;
+  border-bottom: 1px solid #eee;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.container {
+  width: 90%;
+  max-width: 1000px;
+  margin: 0 auto;
+}
+
+.navbar .container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 0;
+}
+
+.logo {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.nav-links {
+  list-style: none;
+  display: flex;
+  gap: 1.5rem;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-links a {
+  text-decoration: none;
+  color: #333;
+  font-weight: 500;
+}
+
+.nav-toggle {
+  display: none;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+}
+
+@media (max-width: 600px) {
+  .nav-links {
+    position: absolute;
+    top: 60px;
+    right: 0;
+    background: #fff;
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 1rem;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+    display: none;
+  }
+
+  .nav-links.open {
+    display: flex;
+  }
+
+  .nav-toggle {
+    display: block;
+  }
+}
+
+.hero {
+  min-height: 90vh;
+  display: flex;
+  align-items: center;
+  text-align: center;
+  background: linear-gradient(135deg, #ff9a9e 0%, #fad0c4 100%);
+  color: #333;
+}
+
+.hero .btn {
+  display: inline-block;
+  margin-top: 1rem;
+  padding: 0.75rem 1.5rem;
+  background: #333;
+  color: #fff;
+  text-decoration: none;
+  border-radius: 4px;
+}
+
+section {
+  padding: 4rem 0;
+  scroll-margin-top: 80px;
+}
+
+.projects-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 2rem;
+}
+
+.project-card img {
+  width: 100%;
+  border-radius: 4px;
+  height: auto;
+}
+
+.contact-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.contact-form input,
+.contact-form textarea {
+  padding: 0.75rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 1rem;
+}
+
+.contact-form button {
+  padding: 0.75rem;
+  border: none;
+  background: #333;
+  color: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+footer {
+  text-align: center;
+  padding: 1rem 0;
+  background: #f4f4f4;
+}
+


### PR DESCRIPTION
## Summary
- redesign site into a full portfolio with hero, about, projects and contact sections
- style the layout with responsive navigation and a gradient hero banner
- add scripts for smooth scrolling, mobile nav toggle, and email-form handler

## Testing
- `npm test --no-update-notifier --no-fund` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c4c0300a483208870fd781c8ce608