### PR TITLE
Add detailed project pages with navigation

### DIFF
--- a/edge-extensions.html
+++ b/edge-extensions.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Microsoft Edge Extensions Revamp</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="navbar">
+    <div class="container">
+      <h1 class="logo">Meghna Sahni</h1>
+      <nav>
+        <ul class="nav-links">
+          <li><a href="index.html#home">Home</a></li>
+          <li><a href="index.html#about">About</a></li>
+          <li><a href="index.html#projects">Projects</a></li>
+          <li><a href="index.html#contact">Contact</a></li>
+        </ul>
+        <button class="nav-toggle" aria-label="toggle navigation">&#9776;</button>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container">
+    <h1>Microsoft Edge Extensions Revamp</h1>
+    <p class="project-meta">Microsoft Edge &vert; Launched in 2024</p>
+
+    <section>
+      <h2>Section 1: Why, what &amp; how</h2>
+      <h3>Why we are solving</h3>
+      <p>Users during their web experience on Edge face two types of problems caused by extensions. They often want to uninstall an extension, stop it from accessing a site, or understand what the extension is doing.</p>
+      <h3>Business Objective</h3>
+      <p>Increase the extension usage of the browser by bringing in more users with intent, increase extension conversions and contextual searches within Edge, and reduce friction in the post-installation journey.</p>
+    </section>
+
+    <section>
+      <h2>Section 1: Experience audit</h2>
+      <p>The experience audit reviewed the existing flow, focusing on tasks and subtasks across the extension lifecycle.</p>
+      <ol>
+        <li>Blocking an extension for a particular domain is difficult.</li>
+        <li>Users struggle when uninstalling or disabling extensions.</li>
+        <li>Removing a batch of extensions from the browser is cumbersome.</li>
+      </ol>
+      <h3>User Goals</h3>
+      <ul>
+        <li>Easily access and search for extensions.</li>
+        <li>Disable an extension whenever needed.</li>
+        <li>Understand what an extension is doing.</li>
+        <li>Uninstall with minimal friction.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Section 2: Design direction &ndash; MVP &amp; northstar vision</h2>
+      <h3>Launched changes</h3>
+      <ul>
+        <li>Updated extension discovery with top categories and curated lists.</li>
+        <li>Improved search, overview pages, and ratings.</li>
+        <li>Introduced clear design patterns for managing extensions within the toolbar.</li>
+      </ul>
+      <h3>Northstar vision</h3>
+      <p>A comprehensive management hub where users can browse, install, and manage extensions with contextual actions and rich information.</p>
+    </section>
+  </main>
+
+  <footer>
+    <p>&copy; <span id="year"></span> Meghna Sahni</p>
+  </footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -41,21 +41,21 @@
     <div class="container">
       <h2>Projects</h2>
       <div class="projects-grid">
-        <div class="project-card">
-          <img src="https://via.placeholder.com/400x300" alt="Project one screenshot" />
-          <h3>Project One</h3>
-          <p>Brief description of the project highlighting tools and impact.</p>
-        </div>
-        <div class="project-card">
-          <img src="https://via.placeholder.com/400x300" alt="Project two screenshot" />
-          <h3>Project Two</h3>
-          <p>Another project summary showcasing problem solving and design.</p>
-        </div>
-        <div class="project-card">
-          <img src="https://via.placeholder.com/400x300" alt="Project three screenshot" />
-          <h3>Project Three</h3>
-          <p>Describe the third project or case study in a sentence or two.</p>
-        </div>
+        <a class="project-card" href="otmh.html">
+          <img src="https://via.placeholder.com/400x300" alt="One time media handling thumbnail" />
+          <h3>One time media handling (OTMH)</h3>
+          <p>Launched in 2023 &ndash; Secure media handling process reducing 24 steps to 5.</p>
+        </a>
+        <a class="project-card" href="monitoring.html">
+          <img src="https://via.placeholder.com/400x300" alt="Monitoring &amp; Control Swimlane thumbnail" />
+          <h3>Monitoring &amp; Control Swimlane</h3>
+          <p>Concept exploration for streamlined labor force management workflows.</p>
+        </a>
+        <a class="project-card" href="edge-extensions.html">
+          <img src="https://via.placeholder.com/400x300" alt="Microsoft Edge Extensions Revamp thumbnail" />
+          <h3>Microsoft Edge Extensions Revamp</h3>
+          <p>Launched in 2024 &ndash; Revamp of extension discovery and management.</p>
+        </a>
       </div>
     </div>
   </section>

--- a/monitoring.html
+++ b/monitoring.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Monitoring &amp; Control Swimlane</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="navbar">
+    <div class="container">
+      <h1 class="logo">Meghna Sahni</h1>
+      <nav>
+        <ul class="nav-links">
+          <li><a href="index.html#home">Home</a></li>
+          <li><a href="index.html#about">About</a></li>
+          <li><a href="index.html#projects">Projects</a></li>
+          <li><a href="index.html#contact">Contact</a></li>
+        </ul>
+        <button class="nav-toggle" aria-label="toggle navigation">&#9776;</button>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container">
+    <h1>Monitoring &amp; Control Swimlane</h1>
+    <p class="project-meta">Amazon Web Services &vert; Concept exploration stage</p>
+
+    <section>
+      <h2>Section 1: Problem hypothesis</h2>
+      <h3>Target Audience</h3>
+      <p><strong>Labor Force Managers (LFMs):</strong> Managers currently jump in to manually assign work and coordinate across teams. They want a more dynamic system that lets them assign multiple tasks quickly, track progress, and reduce the confusion of manual planning.</p>
+      <p><strong>Labor Force Contributors (LFCs):</strong> Contributors struggle to work as a team due to manual coordination. They need clarity on tasks, ways to log progress, escalate blockers, and see skill development paths.</p>
+      <h3>Customer Journey Map</h3>
+      <p>Personas such as LFM Sam and LFC John highlight pain points in planning, tracking, and reporting, emphasizing the need for a streamlined workflow.</p>
+    </section>
+
+    <section>
+      <h2>Section 2: Homepage design screen for LFM &amp; LFC</h2>
+      <p>The LFM homepage summarizes team status, unassigned jobs, and items needing attention, allowing managers to create assignments and monitor work.</p>
+      <p>The LFC homepage focuses on individual contributor tasks, daily goals, and easy actions to log progress or raise blockers.</p>
+    </section>
+  </main>
+
+  <footer>
+    <p>&copy; <span id="year"></span> Meghna Sahni</p>
+  </footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/otmh.html
+++ b/otmh.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>One time media handling (OTMH)</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="navbar">
+    <div class="container">
+      <h1 class="logo">Meghna Sahni</h1>
+      <nav>
+        <ul class="nav-links">
+          <li><a href="index.html#home">Home</a></li>
+          <li><a href="index.html#about">About</a></li>
+          <li><a href="index.html#projects">Projects</a></li>
+          <li><a href="index.html#contact">Contact</a></li>
+        </ul>
+        <button class="nav-toggle" aria-label="toggle navigation">&#9776;</button>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container">
+    <h1>One time media handling (OTMH)</h1>
+    <p class="project-meta">Amazon Web Services &vert; Launched in 2023</p>
+
+    <section>
+      <h2>Section 1: Understanding current system &amp; new experience initiative</h2>
+      <h3>What is OTMH?</h3>
+      <p>One time media handling (OTMH) is a secure media handling process. Today when a data center technician adds or removes a server's hard or solid-state drive, the drives need to be securely stored and processed to maintain AWS policies and ensure customer data protection. The current process has 24 steps. OTMH reduces this to 5 steps with features like a secure bag for storage, built-in instructions through a flow chart, and fast, touch-less destruction.</p>
+      <h3>Target Audience</h3>
+      <p>Data center technicians working in real time.</p>
+      <h3>Launch Plan</h3>
+      <p>Pilots in selected data centers in Dublin's data centers with a broader rollout later in 2023.</p>
+      <p><strong>Current System:</strong> 24 steps &nbsp; | &nbsp; <strong>New System:</strong> 5 steps</p>
+    </section>
+
+    <section>
+      <h2>Section 2: Customer journey map</h2>
+      <p>The journey map walks technicians through a streamlined workflow: bring a batch to the storage station, verify equipment, perform MDM, tag the equipment, and place it into secure storage. Equipment can then be requested, processed, returned to the transfer bay, and signed off with clear audit trails.</p>
+      <p>Design screens prototype guided users visually through each step of the new system.</p>
+    </section>
+  </main>
+
+  <footer>
+    <p>&copy; <span id="year"></span> Meghna Sahni</p>
+  </footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -108,10 +108,24 @@ section {
   gap: 2rem;
 }
 
+.project-card {
+  text-decoration: none;
+  color: inherit;
+  display: block;
+}
+
 .project-card img {
   width: 100%;
   border-radius: 4px;
   height: auto;
+}
+
+.project-card h3 {
+  margin-top: 0.5rem;
+}
+
+.project-card p {
+  margin-bottom: 0;
 }
 
 .contact-form {


### PR DESCRIPTION
## Summary
- Replace placeholder project tiles with links to three detailed projects
- Add CSS to style project cards as links
- Create standalone pages for OTMH, Monitoring & Control Swimlane, and Microsoft Edge Extensions Revamp

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ea6debedc8320bced7056e67efe08